### PR TITLE
Fix issue #79: "A required parameter (userid) was missing" when student clicks Download 

### DIFF
--- a/classes/local/systemreports/userreport.php
+++ b/classes/local/systemreports/userreport.php
@@ -39,7 +39,12 @@ class userreport extends system_report {
         $course = get_course($this->get_context()->instanceid);
         $PAGE->set_context($this->get_context());
 
-        $userid = required_param('userid', PARAM_INT);
+        $parameters = $this->get_parameters();
+
+        if(count($parameters) <= 0){
+            throw new \Exception("Missing parameter userid");
+        }
+        $userid = $parameters[0];
 
         // Our main entity, it contains all of the column definitions that we need.
         $entitymain = new dedication();
@@ -71,8 +76,14 @@ class userreport extends system_report {
      */
     protected function can_view(): bool {
         global $USER;
-        $userid = required_param('userid', PARAM_INT);
-        if ($userid == $USER->id) {
+        $parameters = $this->get_parameters();
+
+        if(count($parameters) <= 0){
+            throw new \Exception("Missing parameter userid");
+        }
+        $userid = $parameters[0];
+
+            if ($userid == $USER->id) {
             return true;
         }
         // Not viewing own report, check if can view others.

--- a/user.php
+++ b/user.php
@@ -64,7 +64,7 @@ $sessionlimit = get_config('block_dedication', 'ignore_sessions_limit');
 if (!empty($sessionlimit)) {
     echo html_writer::div(get_string('excludesessionslessthan', 'block_dedication', utils::format_dedication($sessionlimit)));
 }
-$report = system_report_factory::create(userreport::class, context_course::instance($courseid));
+$report = system_report_factory::create(userreport::class, context_course::instance($courseid), parameters: [$userid]);
 
 echo $report->output();
 echo $OUTPUT->footer();


### PR DESCRIPTION
Hi, 
when i try to use a new version of plugin, I ran into this problem. 
I'm not a developer but wanted to try and fix the problem, which appeared to be in parameter passing. In fact, if I added the `userid` parameter to the download link, it worked.
Therefore I thought of using the `parameters` of the `system_report` class to pass the missing parameter.

I hope it will be useful for you.