### PR TITLE
Added Timespent in a single unit(hours)

### DIFF
--- a/classes/lib/utils.php
+++ b/classes/lib/utils.php
@@ -89,6 +89,9 @@ class utils {
             return get_string('none');
         }
         $totalsecs = abs($totalsecs);
+		$ts2 = abs($totalsecs);
+		$th2 = round($totalsecs / 3600 ,3);
+		
 
         $str = new \stdClass();
         $str->hour = get_string('hour');
@@ -103,13 +106,21 @@ class utils {
         $mins = floor($remainder / MINSECS);
         $secs = round($remainder - ($mins * MINSECS), 2);
 
-        $ss = ($secs == 1) ? $str->sec : $str->secs;
-        $sm = ($mins == 1) ? $str->min : $str->mins;
-        $sh = ($hours == 1) ? $str->hour : $str->hours;
+        // $ss = ($secs == 1) ? $str->sec : $str->secs;
+        // $sm = ($mins == 1) ? $str->min : $str->mins;
+        // $sh = ($hours == 1) ? $str->hour : $str->hours;
+
+        $ss = $str->sec;
+        $sm = $str->min;
+        $sh = $str->hour;
 
         $ohours = '';
         $omins = '';
         $osecs = '';
+		
+		$hours = str_pad($hours, 4, '0', STR_PAD_LEFT);
+		$mins = str_pad($mins, 2, '0', STR_PAD_LEFT);
+		$secs = str_pad($secs, 2, '0', STR_PAD_LEFT);
 
         if ($hours) {
             $ohours = $hours . ' ' . $sh;
@@ -120,20 +131,31 @@ class utils {
         if ($secs) {
             $osecs = $secs . ' ' . $ss;
         }
-
+		
+		$act_hour =  ' = ' . $th2 . ' Hours';
+		// $combo_hour =  $hours . ' ' . $sh . ' ' . $mins . ' ' . $sm . ' ' . $secs . ' ' . $ss. ' = ' . $th2 . ' Hours';
+		$combo_hour =  $ohours . ' ' . $omins . ' ' . $osecs . ' = ' . $th2 . ' Hours';
+		
+		
+/*AZIM*/
         if ($hours) {
-            return trim($ohours . ' ' . $omins);
+			return trim($combo_hour);
+            // return trim($ohours . ' ' . $omins);
         }
         if ($mins) {
             if ($mins < 15) { // If less than 15min, show seconds value as well as minutes.
-                return trim($omins . ' ' . $osecs);
+                // return trim($omins . ' ' . $osecs);
+				return trim($combo_hour);
             } else { // If over 15min, just display a minute value.
-                return trim($omins);
+                // return trim($omins);
+				return trim($combo_hour);
             }
         }
         if ($secs) {
-            return $osecs;
+            // return $osecs
+			return trim($combo_hour);
         }
+/*AZIM*/
         return get_string('none');
     }
 

--- a/classes/local/entities/dedication.php
+++ b/classes/local/entities/dedication.php
@@ -97,6 +97,7 @@ class dedication extends base {
             ->add_joins($this->get_joins())
             ->add_fields("$dedicationalias.timespent")
             ->set_type(column::TYPE_INTEGER)
+            ->set_is_sortable(true)
             ->add_callback(static function(?int $value) {
                 $format = utils::format_dedication($value);
                 return $format;
@@ -110,6 +111,7 @@ class dedication extends base {
             ->add_joins($this->get_joins())
             ->add_fields("$dedicationalias.timestart")
             ->set_type(column::TYPE_TIMESTAMP)
+			->set_is_sortable(true)
             ->set_callback([format::class, 'userdate']);
 
         return $columns;

--- a/classes/local/systemreports/userreport.php
+++ b/classes/local/systemreports/userreport.php
@@ -62,7 +62,6 @@ class userreport extends system_report {
 
         // Set if report can be downloaded.
         $this->set_downloadable(true);
-        $this->set_initial_sort_column('dedication:timestart', SORT_ASC);
     }
 
     /**

--- a/classes/local/systemreports/userreport.php
+++ b/classes/local/systemreports/userreport.php
@@ -62,6 +62,7 @@ class userreport extends system_report {
 
         // Set if report can be downloaded.
         $this->set_downloadable(true);
+        $this->set_initial_sort_column('dedication:timestart', SORT_ASC);
     }
 
     /**


### PR DESCRIPTION
- Added Timespent in a single unit(hours)
- It will be easy to export & sort / split in excel.
- Also works with Aggregation (Average, Sum, etc) in Moodle Custom Report Builder.


*************************************************************************************
![image](https://github.com/catalyst/moodle-block_dedication/assets/35104251/abcfaec5-0bd5-4270-bb7c-5d94e8082155)
*************************************************************************************

![image](https://github.com/catalyst/moodle-block_dedication/assets/35104251/12d2473d-f791-419e-8cb0-ed0e93554aee)
*************************************************************************************

![image](https://github.com/catalyst/moodle-block_dedication/assets/35104251/4e3b9bd4-c9bb-4344-83e0-be38b0283a41)




####
Added Sorting in sessionduration and sessionstart both columns
![image](https://github.com/catalyst/moodle-block_dedication/assets/35104251/66ad3eb1-8c7a-45d9-9f89-26c89142cade)
