### PR TITLE
Fix #105 - Add conditional set_config

### DIFF
--- a/classes/lib/utils.php
+++ b/classes/lib/utils.php
@@ -263,11 +263,11 @@ class utils {
         }
         if (!empty($records)) {
             $DB->insert_records('block_dedication', $records);
-            // Save the last time we saved some records if we haven't stored newer items yet.
-            // Basically prevents cli process for old stuff from saving data.
-            if (get_config('block_dedication', 'lastcalculated') < $timeend) {
-                set_config('lastcalculated', $timeend, 'block_dedication');
-            }
+        }
+
+        // Update lastcalculated entry to prevent re-processing of older timeframes.
+        if (get_config('block_dedication', 'lastcalculated') < $timeend) {
+            set_config('lastcalculated', $timeend, 'block_dedication');
         }
     }
 

--- a/classes/task/dedication_collector.php
+++ b/classes/task/dedication_collector.php
@@ -44,9 +44,7 @@ class dedication_collector extends \core\task\scheduled_task {
      */
     public function execute() {
         $lastruntime = get_config('block_dedication', 'lastcalculated');
-        $isfirsttime = empty($lastruntime);
-
-        if ($isfirsttime) {
+        if (empty($lastruntime)) {
             mtrace("This is the first time this task has been run, calculate data for last 12 weeks");
             // First time this task has been run - lets pull in last 12 weeks of time calculations.
             $lastruntime = time() - WEEKSECS * 12;
@@ -54,12 +52,6 @@ class dedication_collector extends \core\task\scheduled_task {
             mtrace("This task can only be triggered every 2 hours");
             return;
         }
-
-        // If the plugin config entry does not exist we need to create it.
-        if ($isfirsttime) {
-            set_config('lastcalculated', $lastruntime, 'block_dedication');
-        }
-
         utils::generate_stats($lastruntime, time());
     }
 }

--- a/classes/task/dedication_collector.php
+++ b/classes/task/dedication_collector.php
@@ -44,7 +44,9 @@ class dedication_collector extends \core\task\scheduled_task {
      */
     public function execute() {
         $lastruntime = get_config('block_dedication', 'lastcalculated');
-        if (empty($lastruntime)) {
+        $isfirsttime = empty($lastruntime);
+
+        if ($isfirsttime) {
             mtrace("This is the first time this task has been run, calculate data for last 12 weeks");
             // First time this task has been run - lets pull in last 12 weeks of time calculations.
             $lastruntime = time() - WEEKSECS * 12;
@@ -52,6 +54,12 @@ class dedication_collector extends \core\task\scheduled_task {
             mtrace("This task can only be triggered every 2 hours");
             return;
         }
+
+        // If the plugin config entry does not exist we need to create it.
+        if ($isfirsttime) {
+            set_config('lastcalculated', $lastruntime, 'block_dedication');
+        }
+
         utils::generate_stats($lastruntime, time());
     }
 }


### PR DESCRIPTION
If the database table `prefix_config_plugins` does not contain the `lastcalculated` named entry the `dedication_collector` task will behave as if it were being run the for the first time, each run.

Testing:
Delete entry from `prefix_config_plugins` table, run task:
```
Execute scheduled task: Collect data for block dedication (block_dedication\task\dedication_collector)
... started 10:44:00. Current memory use 21.7 MB.
This is the first time this task has been run, calculate data for last 12 weeks
calculating stats from: Wednesday, 29 November 2023, 10:44 AM to:Wednesday, 06 December 2023, 10:44 AM
calculating stats from: Wednesday, 06 December 2023, 10:44 AM to:Wednesday, 13 December 2023, 10:44 AM
calculating stats from: Wednesday, 13 December 2023, 10:44 AM to:Wednesday, 20 December 2023, 10:44 AM
calculating stats from: Wednesday, 20 December 2023, 10:44 AM to:Wednesday, 27 December 2023, 10:44 AM
calculating stats from: Wednesday, 27 December 2023, 10:44 AM to:Wednesday, 03 January 2024, 10:44 AM
calculating stats from: Wednesday, 03 January 2024, 10:44 AM to:Wednesday, 10 January 2024, 10:44 AM
calculating stats from: Wednesday, 10 January 2024, 10:44 AM to:Wednesday, 17 January 2024, 10:44 AM
calculating stats from: Wednesday, 17 January 2024, 10:44 AM to:Wednesday, 24 January 2024, 10:44 AM
calculating stats from: Wednesday, 24 January 2024, 10:44 AM to:Wednesday, 31 January 2024, 10:44 AM
calculating stats from: Wednesday, 31 January 2024, 10:44 AM to:Wednesday, 07 February 2024, 10:44 AM
calculating stats from: Wednesday, 07 February 2024, 10:44 AM to:Wednesday, 14 February 2024, 10:44 AM
... used 13508 dbqueries
... used 1244.7709331512 seconds
Scheduled task complete: Collect data for block dedication (block_dedication\task\dedication_collector)
```

Run task a second time:
```
Execute scheduled task: Collect data for block dedication (block_dedication\task\dedication_collector)
... started 11:07:51. Current memory use 21.7 MB.
This task can only be triggered every 2 hours
... used 0 dbqueries
... used 0.0028460025787354 seconds
Scheduled task complete: Collect data for block dedication (block_dedication\task\dedication_collector)
```