### PR TITLE
Add logstore_standardqueued support

### DIFF
--- a/classes/lib/utils.php
+++ b/classes/lib/utils.php
@@ -33,7 +33,7 @@ class utils {
      *
      * @var array
      */
-    public static $logstores = array('logstore_standard');
+    public static $logstores = array('logstore_standard', 'logstore_standardqueued');
 
     /**
      * Return formatted events from logstores.


### PR DESCRIPTION
Linking: https://github.com/catalyst/moodle-block_dedication/issues/104

Hi Dan, just raising a pull request for this one. The Catalyst plugin `logstore_standardqueued` will store data in the `mdl_logstore_standard_log`. I think it makes sense to support it here.

I've confirmed this is working by enabling `logstore_standardqueued`, running the collector job and have verified that the `block_dedication` table populates.