### PR TITLE
Use correct table name for course completions

### DIFF
--- a/classes/reportbuilder/datasource/user_dedication.php
+++ b/classes/reportbuilder/datasource/user_dedication.php
@@ -144,7 +144,7 @@ class user_dedication extends datasource {
                 'course' => $course,
                 'user' => $user,
             ]);
-        $completion = $completionentity->get_table_alias('course_completion');
+        $completion = $completionentity->get_table_alias('course_completions');
         $this->add_entity($completionentity
             ->add_joins($userentity->get_joins())
             ->add_join("


### PR DESCRIPTION
This displays a warning when creating reports using report builder.
This change in table names was from 2023, MDL-84135.
